### PR TITLE
修复简历解析：PDF 视觉顺序、章节化字段提取、DOCX 后台报错

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "tsc -b && vite build && node scripts/post-build.js",
     "package:extension": "npm run build && node scripts/package-extension.js",
     "lint": "oxlint",
-    "test": "node --experimental-strip-types --test src/shared/backup-sync.test.ts",
+    "test": "node --experimental-strip-types --test src/shared/backup-sync.test.ts src/utils/resume-parse.test.ts src/services/llm/llm-service.test.ts src/parsers/offscreen-routing.test.ts",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -304,6 +304,27 @@ async function handleSaveUserProfile(
   }
 }
 
+/** 去掉空字符串/空白值，避免解析结果把已填字段清空 */
+function dropEmptyValues<T extends object>(source: T | undefined): Partial<T> {
+  if (!source) return {};
+  const result: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(source)) {
+    if (typeof value === 'string' && !value.trim()) continue;
+    if (value === null || value === undefined) continue;
+    result[key] = value;
+  }
+  return result as Partial<T>;
+}
+
+/**
+ * 解析结果为空数组时保留原有内容。
+ * 直接用 `parsed || current` 不行：空数组是真值，会把已有记录清空。
+ */
+function pickNonEmpty<T>(parsed: T[] | undefined, current: T[] | undefined): T[] {
+  if (parsed && parsed.length > 0) return parsed;
+  return current || [];
+}
+
 // 解析简历
 async function handleParseResume(
   fileData: string,
@@ -315,16 +336,22 @@ async function handleParseResume(
     const rawText = preParsedText ?? await parseResume(fileData, fileType);
 
     let parsedData: ParsedResumeData;
+    let parseMethod: 'structured' | 'llm' | 'regex' = 'regex';
+    let llmError: string | undefined;
 
     if (isStructuredType(fileType)) {
       // JSON 简历本身已结构化，直接映射，避免 LLM 二次推断带来的误差
       parsedData = parseStructuredResume(rawText);
+      parseMethod = 'structured';
     } else {
       const llmConfig = await StorageService.getLLMConfig();
       if (llmConfig?.apiKey) {
         try {
           parsedData = await parseResumeWithLLM(rawText, llmConfig);
+          parseMethod = 'llm';
         } catch (error) {
+          // 静默回退会让用户以为 AI 生效了，这里记下原因并回报给界面
+          llmError = error instanceof Error ? error.message : String(error);
           console.warn('LLM resume parsing failed, falling back to regex:', error);
           parsedData = NLPHelper.parseResumeText(rawText);
         }
@@ -336,15 +363,16 @@ async function handleParseResume(
     const currentProfile = await StorageService.getUserProfile();
 
     const updatedProfile: UserProfile = {
+      // 解析结果里的空值不能覆盖用户已填的内容
       personal: {
         ...(currentProfile?.personal || {}),
-        ...(parsedData.personal || {})
+        ...dropEmptyValues(parsedData.personal)
       } as any,
-      education: (parsedData.education || currentProfile?.education || []) as any,
-      experience: (parsedData.experience || currentProfile?.experience || []) as any,
-      projects: (parsedData.projects || currentProfile?.projects || []) as any,
+      education: pickNonEmpty(parsedData.education, currentProfile?.education) as any,
+      experience: pickNonEmpty(parsedData.experience, currentProfile?.experience) as any,
+      projects: pickNonEmpty(parsedData.projects, currentProfile?.projects) as any,
       customInformation: currentProfile?.customInformation || [],
-      skills: parsedData.skills || currentProfile?.skills || [],
+      skills: pickNonEmpty(parsedData.skills, currentProfile?.skills),
       certifications: currentProfile?.certifications || [],
       resume: {
         fileName,
@@ -365,7 +393,9 @@ async function handleParseResume(
       success: true,
       data: {
         parsedData,
-        rawText
+        rawText,
+        parseMethod,
+        llmError
       }
     };
   } catch (error) {

--- a/src/offscreen/index.ts
+++ b/src/offscreen/index.ts
@@ -1,34 +1,46 @@
-// Offscreen document for PDF parsing
-// This runs in a DOM context, so PDF.js can access window object
+// Offscreen document：在有 DOM 的上下文里解析简历文件。
+// PDF.js 需要 DOM；mammoth 的依赖 bluebird 在挑选调度器时也可能触碰
+// document，两者都不宜在 service worker 中直接运行。
 
 import { parsePDF } from '../parsers/pdfParser';
+import { parseDOCX } from '../parsers/docxParser';
 
-console.log('Offscreen document loaded, waiting for PDF parsing requests...');
+console.log('Offscreen document loaded, waiting for parsing requests...');
+
+function parseByType(fileType: string, fileData: string): Promise<string> {
+  switch (fileType.toLowerCase().replace('.', '')) {
+    case 'pdf':
+      return parsePDF(fileData);
+    case 'doc':
+    case 'docx':
+      return parseDOCX(fileData);
+    default:
+      return Promise.reject(new Error(`Offscreen 不支持的格式：${fileType}`));
+  }
+}
 
 chrome.runtime.onMessage.addListener(
   (message, _sender, sendResponse) => {
-    console.log('Offscreen received message:', message.type);
+    if (message?.type !== 'PARSE_FILE_OFFSCREEN') return false;
 
-    if (message.type === 'PARSE_PDF_OFFSCREEN') {
-      console.log('Starting PDF parsing in offscreen document...');
+    const { fileType, fileData } = message.payload ?? {};
+    console.log(`Starting ${fileType} parsing in offscreen document...`);
 
-      parsePDF(message.payload.fileData)
-        .then((text) => {
-          console.log('PDF parsed successfully, text length:', text.length);
-          sendResponse({ success: true, data: text });
-        })
-        .catch((error) => {
-          console.error('PDF parsing error in offscreen:', error);
-          sendResponse({
-            success: false,
-            error: error instanceof Error ? error.message : 'Failed to parse PDF'
-          });
+    parseByType(String(fileType ?? ''), String(fileData ?? ''))
+      .then((text) => {
+        console.log('Parsed successfully, text length:', text.length);
+        sendResponse({ success: true, data: text });
+      })
+      .catch((error) => {
+        console.error('Parsing error in offscreen:', error);
+        sendResponse({
+          success: false,
+          error: error instanceof Error ? error.message : 'Failed to parse file'
         });
-      return true; // 异步响应
-    }
+      });
 
-    return false;
+    return true; // 异步响应
   }
 );
 
-console.log('Offscreen document ready for PDF parsing');
+console.log('Offscreen document ready for parsing');

--- a/src/options/AISettings.tsx
+++ b/src/options/AISettings.tsx
@@ -194,6 +194,12 @@ export function AISettings({ dataRevision = 0 }: AISettingsProps) {
         <datalist id="model-suggestions">
           {preset.models.map(m => <option key={m} value={m} />)}
         </datalist>
+
+        <p className="settings-hint">
+          推荐使用非推理模型。推理模型的思考内容会占用输出额度，
+          容易在思考阶段耗尽额度而返回空内容，届时会自动改用本地规则解析。
+        </p>
+
         {modelEdited && preset.defaultModel && config.model.trim() !== preset.defaultModel ? (
           <p className="settings-hint">
             已使用自定义模型，切换服务商时不会被覆盖。
@@ -203,7 +209,16 @@ export function AISettings({ dataRevision = 0 }: AISettingsProps) {
           </p>
         ) : preset.models.length > 0 && (
           <p className="settings-hint">
-            常用模型：{preset.models.join('、')}。模型更新较快，如提示模型不存在请到官方文档核对名称。
+            非推理模型：{preset.models.join('、')}。模型更新较快，如提示模型不存在请到官方文档核对名称。
+          </p>
+        )}
+
+        {preset.reasoningOnly && (
+          <p className="settings-hint">
+            {preset.label} 目前在售的
+            {(preset.reasoningModels ?? []).join('、')} 均为推理模型，
+            建议改用 DeepSeek（deepseek-chat）、GLM（glm-4-flash）
+            或 Qwen（qwen-plus）等非推理模型。
           </p>
         )}
       </div>

--- a/src/options/App.tsx
+++ b/src/options/App.tsx
@@ -1,11 +1,17 @@
 import React, { useState, useEffect } from 'react';
 import { MessageService } from '../shared/message';
-import type { UserProfile, PersonalInfo, CustomInformation } from '../shared/types';
+import type {
+  UserProfile,
+  PersonalInfo,
+  CustomInformation,
+  ParsedResumeData,
+} from '../shared/types';
 import { AISettings } from './AISettings';
 import { EducationSection } from './EducationSection';
 import { ExperienceSection } from './ExperienceSection';
 import { DataSyncSettings } from './DataSyncSettings';
 import { parsePDF } from '../parsers/pdfParser';
+import { parseDOCX } from '../parsers/docxParser';
 
 /** MIME 类型到扩展名的兜底映射，用于文件名缺少扩展名的情况 */
 const MIME_TO_EXT: Record<string, string> = {
@@ -32,6 +38,47 @@ function resolveFileType(file: File): string {
   return MIME_TO_EXT[file.type] || ext;
 }
 
+/**
+ * 汇总本次实际提取到的内容，用于上传后的提示。
+ * 解析请求成功不代表提取到了字段，提示需要如实反映结果。
+ */
+function summarizeParsed(data: ParsedResumeData | undefined): string {
+  if (!data) return '';
+
+  const personalCount = Object.values(data.personal || {})
+    .filter(value => typeof value === 'string' && value.trim()).length;
+
+  const parts: string[] = [];
+  if (personalCount > 0) parts.push(`个人信息 ${personalCount} 项`);
+  if (data.education?.length) parts.push(`教育经历 ${data.education.length} 条`);
+  if (data.experience?.length) parts.push(`工作/实习经历 ${data.experience.length} 条`);
+  if (data.projects?.length) parts.push(`项目经历 ${data.projects.length} 条`);
+  if (data.skills?.length) parts.push(`技能 ${data.skills.length} 项`);
+
+  return parts.join('、');
+}
+
+/**
+ * 在设置页（有 DOM）先把需要 DOM 的格式解析成文本。
+ * PDF.js 需要 DOM；mammoth 的依赖 bluebird 在 service worker 中挑选调度器时
+ * 可能触碰 document 而报 ReferenceError，故一并在此处理。
+ * 其余纯文本格式返回 undefined，交由后台解析。
+ */
+async function preParseInPage(
+  fileType: string,
+  base64Data: string
+): Promise<string | undefined> {
+  switch (fileType) {
+    case 'pdf':
+      return await parsePDF(base64Data);
+    case 'doc':
+    case 'docx':
+      return await parseDOCX(base64Data);
+    default:
+      return undefined;
+  }
+}
+
 function resizeAutoGrowTextarea(element: HTMLTextAreaElement): void {
   const singleLineHeight = 39;
   element.style.height = 'auto';
@@ -54,7 +101,7 @@ function App() {
   const [dataRevision, setDataRevision] = useState(0);
   const [parsingResume, setParsingResume] = useState(false);
   const [resumeNotice, setResumeNotice] = useState<{
-    type: 'info' | 'success' | 'error';
+    type: 'info' | 'success' | 'warning' | 'error';
     text: string;
   } | null>(null);
   const [saveNotice, setSaveNotice] = useState<{
@@ -193,9 +240,9 @@ function App() {
       const fileType = resolveFileType(file);
 
       try {
-        const rawText = fileType === 'pdf'
-          ? await parsePDF(base64Data)
-          : undefined;
+        // PDF 与 DOCX 依赖的库需要 DOM，在设置页（有 DOM）先解析出文本，
+        // 后台就无需再触碰这些库
+        const rawText = await preParseInPage(fileType, base64Data);
 
         const response = await MessageService.sendMessage({
           type: 'PARSE_RESUME',
@@ -208,8 +255,35 @@ function App() {
         });
 
         if (response.success && response.data) {
+          const result = response.data as {
+            parsedData?: ParsedResumeData;
+            parseMethod?: 'structured' | 'llm' | 'regex';
+            llmError?: string;
+          };
+          const summary = summarizeParsed(result.parsedData);
           setSaveNotice({ type: 'success', text: '简历解析成功，请检查并确认提取的信息' });
-          setResumeNotice({ type: 'success', text: `「${file.name}」解析完成，已更新到当前资料。` });
+
+          if (result.llmError) {
+            // AI 解析失败会静默回退到正则，必须让用户知道，否则会误以为 AI 生效了
+            setResumeNotice({
+              type: 'warning',
+              text: `「${file.name}」AI 解析失败，已改用本地规则解析${summary ? `，提取 ${summary}` : '，未提取到字段'}。`
+                + `失败原因：${result.llmError}`,
+            });
+          } else if (summary) {
+            const prefix = result.parseMethod === 'llm' ? 'AI 解析完成' : '解析完成';
+            setResumeNotice({
+              type: 'success',
+              text: `「${file.name}」${prefix}，已提取 ${summary}，请核对。`,
+            });
+          } else {
+            setResumeNotice({
+              type: 'warning',
+              text: `「${file.name}」已读取，但没能提取到可用字段。`
+                + '若为扫描版 PDF（图片型）需改用文字版；也可在设置中配置 AI 服务提升提取效果。',
+            });
+          }
+
           loadProfile();
         } else {
           const message = response.error || '未知错误';

--- a/src/options/index.css
+++ b/src/options/index.css
@@ -382,6 +382,12 @@ textarea:focus {
   background: #ecfdf5;
 }
 
+.resume-notice.warning {
+  border-color: #fde68a;
+  color: #92400e;
+  background: #fffbeb;
+}
+
 .resume-notice.error {
   border-color: #fecaca;
   color: #b91c1c;

--- a/src/parsers/index.ts
+++ b/src/parsers/index.ts
@@ -1,8 +1,8 @@
-import { parsePDF } from './pdfParser';
-import { parseDOCX } from './docxParser';
-import { parseMarkdown } from './markdownParser';
-import { parseTXT } from './txtParser';
-import { parseResumeJSON } from './jsonParser';
+import { parsePDF } from './pdfParser.ts';
+import { parseDOCX } from './docxParser.ts';
+import { parseMarkdown } from './markdownParser.ts';
+import { parseTXT } from './txtParser.ts';
+import { parseResumeJSON } from './jsonParser.ts';
 import type { ParsedResumeData } from '../shared/types';
 
 /** JSON 简历自带结构，无需再经 LLM/正则推断 */
@@ -10,19 +10,35 @@ export function isStructuredType(fileType: string): boolean {
   return fileType.toLowerCase().replace('.', '') === 'json';
 }
 
+/**
+ * 必须在有 DOM 的上下文中解析的格式。
+ *
+ * - PDF：PDF.js 需要 DOM。
+ * - DOC/DOCX：mammoth 本身用纯 JS 的 @xmldom/xmldom，但其依赖 bluebird 在
+ *   模块求值时挑选调度器：service worker 没有 process 却有 MutationObserver，
+ *   一旦 bluebird 判定拿不到原生 Promise，就会走 document.createElement 分支
+ *   并抛 ReferenceError。与其依赖该判定的结果，不如始终放到有 DOM 的上下文里跑。
+ */
+const DOM_REQUIRED_TYPES = ['pdf', 'doc', 'docx'];
+
 export async function parseResume(
   base64Data: string,
   fileType: string
 ): Promise<string> {
   const normalizedType = fileType.toLowerCase().replace('.', '');
 
+  // 在 service worker 中，通过 offscreen document 处理
+  if (
+    DOM_REQUIRED_TYPES.includes(normalizedType) &&
+    typeof window === 'undefined' &&
+    typeof chrome !== 'undefined' &&
+    canUseOffscreenDocument()
+  ) {
+    return await parseInOffscreen(base64Data, normalizedType);
+  }
+
   switch (normalizedType) {
     case 'pdf':
-      // PDF 解析需要在有 DOM 环境中执行
-      // 在 service worker 中，通过 offscreen document 处理
-      if (typeof window === 'undefined' && typeof chrome !== 'undefined' && canUseOffscreenDocument()) {
-        return await parsePDFInOffscreen(base64Data);
-      }
       return await parsePDF(base64Data);
     case 'doc':
     case 'docx':
@@ -50,14 +66,16 @@ function canUseOffscreenDocument(): boolean {
   );
 }
 
-/** 在 offscreen document 中解析 PDF（用于 service worker 环境） */
-async function parsePDFInOffscreen(base64Data: string): Promise<string> {
+/** 在 offscreen document 中解析需要 DOM 的格式（用于 service worker 环境） */
+async function parseInOffscreen(base64Data: string, fileType: string): Promise<string> {
+  const parseDirectly = () => (fileType === 'pdf' ? parsePDF(base64Data) : parseDOCX(base64Data));
+
   try {
-    console.log('Attempting to parse PDF in offscreen document...');
+    console.log(`Attempting to parse ${fileType} in offscreen document...`);
 
     if (!canUseOffscreenDocument()) {
-      console.warn('Offscreen API unavailable, falling back to direct PDF parsing');
-      return await parsePDF(base64Data);
+      console.warn('Offscreen API unavailable, falling back to direct parsing');
+      return await parseDirectly();
     }
 
     // 确保 offscreen document 存在
@@ -74,28 +92,30 @@ async function parsePDFInOffscreen(base64Data: string): Promise<string> {
       await chrome.offscreen.createDocument({
         url: 'src/offscreen/index.html',
         reasons: ['DOM_PARSER' as chrome.offscreen.Reason],
-        justification: 'Parse PDF files using PDF.js which requires DOM',
+        justification: 'Parse PDF and DOCX resumes with libraries that require DOM',
       });
       console.log('Offscreen document created');
     }
 
     // 发送消息到 offscreen document
-    console.log('Sending PDF data to offscreen document...');
+    console.log(`Sending ${fileType} data to offscreen document...`);
     const response = await chrome.runtime.sendMessage({
-      type: 'PARSE_PDF_OFFSCREEN',
-      payload: { fileData: base64Data }
+      type: 'PARSE_FILE_OFFSCREEN',
+      payload: { fileData: base64Data, fileType }
     });
 
     console.log('Received response from offscreen:', response);
 
-    if (!response.success) {
-      throw new Error(response.error || 'Failed to parse PDF');
+    if (!response?.success) {
+      throw new Error(response?.error || `Failed to parse ${fileType}`);
     }
 
     return response.data;
   } catch (error) {
-    console.error('Error in parsePDFInOffscreen:', error);
-    throw new Error(`PDF parsing failed: ${error instanceof Error ? error.message : String(error)}`);
+    console.error('Error in parseInOffscreen:', error);
+    throw new Error(
+      `${fileType.toUpperCase()} parsing failed: ${error instanceof Error ? error.message : String(error)}`
+    );
   }
 }
 

--- a/src/parsers/offscreen-routing.test.ts
+++ b/src/parsers/offscreen-routing.test.ts
@@ -1,0 +1,117 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { parseResume } from './index.ts';
+
+/**
+ * 这些用例守住一件事：service worker 里不能直接跑需要 DOM 的解析库。
+ * DOCX 曾因 mammoth 的依赖 bluebird 在无 DOM 环境挑选调度器时触碰
+ * document，报 "document is not defined"。
+ */
+
+interface SentMessage {
+  type: string;
+  payload: { fileData: string; fileType: string };
+}
+
+/** 模拟 service worker：无 window，chrome.offscreen 可用 */
+function stubServiceWorker(offscreenReply: string) {
+  const sent: SentMessage[] = [];
+  const created: string[] = [];
+  const originalChrome = (globalThis as any).chrome;
+
+  (globalThis as any).chrome = {
+    runtime: {
+      getContexts: async () => [],
+      sendMessage: async (message: SentMessage) => {
+        sent.push(message);
+        return { success: true, data: offscreenReply };
+      },
+    },
+    offscreen: {
+      createDocument: async (opts: { url: string }) => { created.push(opts.url); },
+    },
+  };
+
+  return {
+    sent,
+    created,
+    restore: () => { (globalThis as any).chrome = originalChrome; },
+  };
+}
+
+test('service worker 中 DOCX 交给 offscreen 解析', async () => {
+  const stub = stubServiceWorker('DOCX 文本');
+  try {
+    const text = await parseResume('ZmFrZQ==', 'docx');
+    assert.equal(text, 'DOCX 文本');
+    assert.equal(stub.sent.length, 1);
+    assert.equal(stub.sent[0].type, 'PARSE_FILE_OFFSCREEN');
+    assert.equal(stub.sent[0].payload.fileType, 'docx');
+  } finally {
+    stub.restore();
+  }
+});
+
+test('service worker 中 PDF 同样交给 offscreen 解析', async () => {
+  const stub = stubServiceWorker('PDF 文本');
+  try {
+    assert.equal(await parseResume('ZmFrZQ==', 'pdf'), 'PDF 文本');
+    assert.equal(stub.sent[0].payload.fileType, 'pdf');
+  } finally {
+    stub.restore();
+  }
+});
+
+test('.doc 与带点的扩展名也走 offscreen', async () => {
+  for (const fileType of ['doc', '.docx', 'DOCX']) {
+    const stub = stubServiceWorker('文本');
+    try {
+      await parseResume('ZmFrZQ==', fileType);
+      assert.equal(stub.sent.length, 1, `${fileType} 未走 offscreen`);
+    } finally {
+      stub.restore();
+    }
+  }
+});
+
+test('offscreen document 只创建一次并复用', async () => {
+  const stub = stubServiceWorker('文本');
+  try {
+    await parseResume('ZmFrZQ==', 'docx');
+    assert.deepEqual(stub.created, ['src/offscreen/index.html']);
+  } finally {
+    stub.restore();
+  }
+});
+
+test('纯文本格式不经过 offscreen', async () => {
+  const stub = stubServiceWorker('不应被使用');
+  try {
+    // "abc" 的 base64
+    const text = await parseResume('YWJj', 'txt');
+    assert.equal(text, 'abc');
+    assert.equal(stub.sent.length, 0, 'TXT 不应发送 offscreen 消息');
+  } finally {
+    stub.restore();
+  }
+});
+
+test('offscreen 返回失败时抛出可读错误', async () => {
+  const originalChrome = (globalThis as any).chrome;
+  (globalThis as any).chrome = {
+    runtime: {
+      getContexts: async () => [],
+      sendMessage: async () => ({ success: false, error: '磁盘已满' }),
+    },
+    offscreen: { createDocument: async () => {} },
+  };
+  try {
+    await assert.rejects(parseResume('ZmFrZQ==', 'docx'), /磁盘已满/);
+  } finally {
+    (globalThis as any).chrome = originalChrome;
+  }
+});
+
+test('不支持的格式给出明确提示', async () => {
+  await assert.rejects(parseResume('ZmFrZQ==', 'xlsx'), /不支持的文件格式/);
+});

--- a/src/parsers/pdfParser.ts
+++ b/src/parsers/pdfParser.ts
@@ -67,12 +67,7 @@ export async function parsePDF(base64Data: string): Promise<string> {
       const page = await pdf.getPage(pageNum);
       const textContent = await page.getTextContent();
 
-      // 提取文本
-      const pageText = textContent.items
-        .map((item: any) => item.str)
-        .join(' ');
-
-      fullText += pageText + '\n';
+      fullText += itemsToText(textContent.items) + '\n';
     }
 
     return fullText.trim();
@@ -84,4 +79,131 @@ export async function parsePDF(base64Data: string): Promise<string> {
       : String(error);
     throw new Error(`Failed to parse PDF file: ${errorMessage}`);
   }
+}
+
+interface PDFTextItem {
+  str?: string;
+  hasEOL?: boolean;
+  width?: number;
+  height?: number;
+  transform?: number[];
+}
+
+interface PositionedItem {
+  str: string;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+/**
+ * 把一页的文本块还原成带换行、且符合视觉顺序的文本。
+ *
+ * 两个必须处理的问题：
+ *
+ * 1. PDF 没有「行」的概念，只有一堆带坐标的文本块。直接用空格拼接会让
+ *    整页变成一行，后续按行工作的字段提取全部失效。
+ * 2. 内容流顺序不等于视觉顺序。Canva 等设计工具常把章节标题放在独立
+ *    图层最后绘制，于是「教育经历」「实习经历」这类标题会排到全文末尾，
+ *    与各自的内容彻底脱节，LLM 和正则都无法判断段落归属。
+ *
+ * 因此这里不沿用内容流顺序，而是按坐标重排：先用 Y 坐标聚成行
+ * （自上而下），行内再按 X 排序（自左而右）。
+ */
+function itemsToText(items: unknown[]): string {
+  const positioned: PositionedItem[] = [];
+
+  for (const raw of items) {
+    const item = raw as PDFTextItem;
+    // getTextContent 的结果里混有标记内容项，没有 str 字段
+    if (typeof item.str !== 'string' || !item.str.trim()) continue;
+
+    const transform = Array.isArray(item.transform) ? item.transform : null;
+    if (!transform || !Number.isFinite(transform[4]) || !Number.isFinite(transform[5])) {
+      continue;
+    }
+
+    positioned.push({
+      str: item.str,
+      x: transform[4] as number,
+      y: transform[5] as number,
+      width: Number.isFinite(item.width) ? (item.width as number) : 0,
+      height: Number.isFinite(item.height) && (item.height as number) > 0
+        ? (item.height as number)
+        : 12,
+    });
+  }
+
+  if (positioned.length === 0) return '';
+
+  return groupIntoLines(positioned)
+    .map(joinLine)
+    .join('\n')
+    .replace(/[ \t]+$/gm, '');
+}
+
+/** 按 Y 坐标把文本块聚成行，行内按 X 升序 */
+function groupIntoLines(items: PositionedItem[]): PositionedItem[][] {
+  // Y 降序（PDF 坐标系原点在左下，Y 大者在上）
+  const sorted = [...items].sort((a, b) => b.y - a.y);
+
+  const lines: PositionedItem[][] = [];
+  let currentLine: PositionedItem[] = [];
+  let lineY = sorted[0].y;
+  let lineHeight = sorted[0].height;
+
+  for (const item of sorted) {
+    // 同一视觉行的基线可能有零点几的抖动（如日期块比正文高 0.8），
+    // 用半个字高作容差；超出则判为新行。
+    const tolerance = Math.max(lineHeight, item.height) * 0.5;
+
+    if (currentLine.length > 0 && Math.abs(item.y - lineY) > tolerance) {
+      lines.push(currentLine);
+      currentLine = [];
+    }
+
+    if (currentLine.length === 0) {
+      lineY = item.y;
+      lineHeight = item.height;
+    } else {
+      // 以行内最大字高为准，避免小字块把容差压得过小
+      lineHeight = Math.max(lineHeight, item.height);
+    }
+
+    currentLine.push(item);
+  }
+
+  if (currentLine.length > 0) lines.push(currentLine);
+
+  return lines.map(line => line.sort((a, b) => a.x - b.x));
+}
+
+/**
+ * 拼接一行内的文本块。中文 PDF 常把相邻字拆成多个块，
+ * 无条件加空格会在词内插入空格，因此只在水平间距明显时补空格。
+ */
+function joinLine(line: PositionedItem[]): string {
+  let text = '';
+  let prevEndX: number | null = null;
+  let prevHeight = 0;
+
+  for (const item of line) {
+    const gapThreshold = Math.max(item.height, prevHeight) * 0.25;
+
+    if (
+      text &&
+      prevEndX !== null &&
+      item.x - prevEndX > gapThreshold &&
+      !/\s$/.test(text)
+    ) {
+      text += ' ';
+    }
+
+    text += item.str;
+    prevEndX = item.x + item.width;
+    prevHeight = item.height;
+  }
+
+  return text.trim();
 }

--- a/src/services/llm/llm-service.test.ts
+++ b/src/services/llm/llm-service.test.ts
@@ -1,0 +1,186 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { LLMService } from './llmService.ts';
+import {
+  LLMProvider,
+  PROVIDER_PRESETS,
+  PROVIDER_ORDER,
+  DEFAULT_MAX_TOKENS,
+  MAX_TOKENS_CEILING,
+} from './types.ts';
+
+const baseConfig = {
+  provider: LLMProvider.MIMO,
+  apiKey: 'test-key',
+  baseUrl: 'https://example.com/v1',
+  model: 'mimo-v2.5-pro',
+};
+
+/** 记录每次请求的 max_tokens，并按 handler 决定返回体 */
+function stubFetch(handler: (maxTokens: number, call: number) => unknown) {
+  const budgets: number[] = [];
+  const originalFetch = globalThis.fetch;
+
+  globalThis.fetch = (async (_input: unknown, init?: { body?: string }) => {
+    const body = JSON.parse(init?.body ?? '{}');
+    budgets.push(body.max_tokens);
+    return new Response(JSON.stringify(handler(body.max_tokens, budgets.length)), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }) as typeof globalThis.fetch;
+
+  return { budgets, restore: () => { globalThis.fetch = originalFetch; } };
+}
+
+/** 推理模型思考耗尽额度时的响应：finish_reason=length 且正文为空 */
+const truncated = { choices: [{ message: { content: '' }, finish_reason: 'length' }] };
+const ok = { choices: [{ message: { content: '{"ok":true}' }, finish_reason: 'stop' }] };
+
+test('默认输出上限不再是导致推理模型返回空正文的 4096', () => {
+  assert.ok(DEFAULT_MAX_TOKENS >= 8192, `默认额度过低：${DEFAULT_MAX_TOKENS}`);
+});
+
+test('未配置 maxTokens 时使用默认额度', async () => {
+  const stub = stubFetch(() => ok);
+  try {
+    await new LLMService(baseConfig).chat([{ role: 'user', content: 'hi' }]);
+    assert.deepEqual(stub.budgets, [DEFAULT_MAX_TOKENS]);
+  } finally {
+    stub.restore();
+  }
+});
+
+test('思考耗尽额度返回空正文时自动加倍重试', async () => {
+  const stub = stubFetch((_max, call) => (call === 1 ? truncated : ok));
+  try {
+    const result = await new LLMService(baseConfig).chat([{ role: 'user', content: 'hi' }]);
+    assert.equal(result.content, '{"ok":true}');
+    assert.deepEqual(stub.budgets, [DEFAULT_MAX_TOKENS, DEFAULT_MAX_TOKENS * 2]);
+  } finally {
+    stub.restore();
+  }
+});
+
+test('加倍到 32768 上限即停止使用 AI 解析', async () => {
+  const stub = stubFetch(() => truncated);
+  try {
+    await assert.rejects(
+      new LLMService(baseConfig).chat([{ role: 'user', content: 'hi' }]),
+      (error: Error) => {
+        assert.match(error.message, new RegExp(String(MAX_TOKENS_CEILING)));
+        assert.match(error.message, /已停止使用 AI 解析/);
+        assert.match(error.message, /非推理模型/);
+        return true;
+      }
+    );
+    // 8192 → 16384 → 32768 后停止，不会无限重试
+    assert.deepEqual(stub.budgets, [8192, 16384, 32768]);
+  } finally {
+    stub.restore();
+  }
+});
+
+test('旧配置里较小的 maxTokens 不会把额度压到 8192 以下', async () => {
+  const stub = stubFetch(() => ok);
+  try {
+    await new LLMService({ ...baseConfig, maxTokens: 2048 })
+      .chat([{ role: 'user', content: 'hi' }]);
+    assert.deepEqual(stub.budgets, [DEFAULT_MAX_TOKENS]);
+  } finally {
+    stub.restore();
+  }
+});
+
+test('额度请求不超过上限', async () => {
+  const stub = stubFetch(() => ok);
+  try {
+    await new LLMService({ ...baseConfig, maxTokens: 999999 })
+      .chat([{ role: 'user', content: 'hi' }]);
+    assert.deepEqual(stub.budgets, [MAX_TOKENS_CEILING]);
+  } finally {
+    stub.restore();
+  }
+});
+
+test('非截断类错误不触发重试', async () => {
+  const stub = stubFetch(() => ({ choices: [{ message: { content: '' }, finish_reason: 'stop' }] }));
+  try {
+    await assert.rejects(
+      new LLMService(baseConfig).chat([{ role: 'user', content: 'hi' }]),
+      /返回内容为空/
+    );
+    assert.equal(stub.budgets.length, 1, '不应重试');
+  } finally {
+    stub.restore();
+  }
+});
+
+test('Claude 开启 thinking 时取文本 block 而非思考 block', async () => {
+  const stub = stubFetch(() => ({
+    content: [
+      { type: 'thinking', thinking: '让我想想…' },
+      { type: 'text', text: '{"ok":true}' },
+    ],
+    stop_reason: 'end_turn',
+  }));
+  try {
+    const result = await new LLMService({
+      ...baseConfig,
+      provider: LLMProvider.CLAUDE,
+      baseUrl: 'https://api.anthropic.com',
+      model: 'claude-sonnet-4-5',
+    }).chat([{ role: 'user', content: 'hi' }]);
+    assert.equal(result.content, '{"ok":true}');
+  } finally {
+    stub.restore();
+  }
+});
+
+test('各服务商默认模型不是推理模型', () => {
+  for (const provider of PROVIDER_ORDER) {
+    const preset = PROVIDER_PRESETS[provider];
+    if (!preset.defaultModel || preset.reasoningOnly) continue;
+
+    assert.ok(
+      !(preset.reasoningModels ?? []).includes(preset.defaultModel),
+      `${preset.label} 的默认模型 ${preset.defaultModel} 是推理模型`
+    );
+    assert.ok(
+      preset.models.includes(preset.defaultModel),
+      `${preset.label} 的默认模型 ${preset.defaultModel} 不在非推理模型候选中`
+    );
+  }
+});
+
+test('仅有推理模型的服务商被标记出来', () => {
+  for (const provider of PROVIDER_ORDER) {
+    const preset = PROVIDER_PRESETS[provider];
+    if (provider === LLMProvider.CUSTOM) continue;
+
+    if (preset.models.length === 0) {
+      assert.equal(
+        preset.reasoningOnly, true,
+        `${preset.label} 没有非推理模型候选，应标记 reasoningOnly 以便界面提示`
+      );
+    }
+  }
+});
+
+test('Claude 因 max_tokens 截断时同样自动重试', async () => {
+  const stub = stubFetch((_max, call) => (call === 1
+    ? { content: [{ type: 'thinking', thinking: '…' }], stop_reason: 'max_tokens' }
+    : { content: [{ type: 'text', text: 'done' }], stop_reason: 'end_turn' }));
+  try {
+    const result = await new LLMService({
+      ...baseConfig,
+      provider: LLMProvider.CLAUDE,
+      baseUrl: 'https://api.anthropic.com',
+      model: 'claude-sonnet-4-5',
+    }).chat([{ role: 'user', content: 'hi' }]);
+    assert.equal(result.content, 'done');
+    assert.deepEqual(stub.budgets, [DEFAULT_MAX_TOKENS, DEFAULT_MAX_TOKENS * 2]);
+  } finally {
+    stub.restore();
+  }
+});

--- a/src/services/llm/llmService.ts
+++ b/src/services/llm/llmService.ts
@@ -1,5 +1,18 @@
 import type { LLMConfig, ChatMessage, LLMResponse } from './types';
-import { LLMProvider } from './types';
+import { LLMProvider, DEFAULT_MAX_TOKENS, MAX_TOKENS_CEILING } from './types.ts';
+
+/** 输出被 max_tokens 截断且正文为空时抛出，供上层决定是否加大额度重试 */
+export class TruncatedEmptyOutputError extends Error {
+  attemptedMaxTokens: number;
+
+  constructor(attemptedMaxTokens: number) {
+    super(
+      `模型在 max_tokens=${attemptedMaxTokens} 下于思考阶段耗尽额度，未产出正文。`,
+    );
+    this.name = 'TruncatedEmptyOutputError';
+    this.attemptedMaxTokens = attemptedMaxTokens;
+  }
+}
 
 export class LLMService {
   private config: LLMConfig;
@@ -8,11 +21,40 @@ export class LLMService {
     this.config = config;
   }
 
+  /**
+   * 发起对话。
+   *
+   * 输出额度从 DEFAULT_MAX_TOKENS 起算。若模型因思考耗尽额度而返回空正文，
+   * 自动加倍重试，直到 MAX_TOKENS_CEILING 为止——推理模型的思考长度无法预估，
+   * 界面上也不再暴露该设置，所以由这里自动试探。
+   * 到上限仍失败即放弃，由调用方回退到本地规则解析。
+   */
   async chat(messages: ChatMessage[], signal?: AbortSignal): Promise<LLMResponse> {
-    if (this.config.provider === LLMProvider.CLAUDE) {
-      return this.callClaude(messages, signal);
+    // 旧配置里可能存有更小的 maxTokens，不能让它把额度压到默认值以下
+    let budget = Math.min(
+      Math.max(this.config.maxTokens ?? 0, DEFAULT_MAX_TOKENS),
+      MAX_TOKENS_CEILING,
+    );
+
+    for (;;) {
+      try {
+        return this.config.provider === LLMProvider.CLAUDE
+          ? await this.callClaude(messages, signal, budget)
+          : await this.callOpenAICompatible(messages, signal, budget);
+      } catch (error) {
+        if (!(error instanceof TruncatedEmptyOutputError)) throw error;
+
+        if (budget >= MAX_TOKENS_CEILING) {
+          throw new Error(
+            `模型已在 max_tokens 提升至上限 ${MAX_TOKENS_CEILING} 后仍未产出正文，`
+            + '已停止使用 AI 解析。该模型的思考过程过长，请在「AI 模型设置」中改用非推理模型。',
+          );
+        }
+
+        budget = Math.min(budget * 2, MAX_TOKENS_CEILING);
+        console.warn(`Output truncated with empty content, retrying with max_tokens=${budget}`);
+      }
     }
-    return this.callOpenAICompatible(messages, signal);
   }
 
   /** 去掉用户粘贴地址时常见的结尾斜杠，避免出现 //chat/completions */
@@ -28,7 +70,11 @@ export class LLMService {
     return this.trimmedBaseUrl().replace(/\/v1$/, '');
   }
 
-  private async callOpenAICompatible(messages: ChatMessage[], signal?: AbortSignal): Promise<LLMResponse> {
+  private async callOpenAICompatible(
+    messages: ChatMessage[],
+    signal: AbortSignal | undefined,
+    maxTokens: number,
+  ): Promise<LLMResponse> {
     const response = await fetch(`${this.trimmedBaseUrl()}/chat/completions`, {
       method: 'POST',
       headers: {
@@ -39,7 +85,7 @@ export class LLMService {
         model: this.config.model,
         messages,
         temperature: this.config.temperature ?? 0.7,
-        max_tokens: this.config.maxTokens ?? 4096,
+        max_tokens: maxTokens,
       }),
       signal,
     });
@@ -60,10 +106,10 @@ export class LLMService {
     const content = data.choices?.[0]?.message?.content;
     if (typeof content !== 'string' || content.trim() === '') {
       // 推理模型（如 mimo-v2.5-pro、deepseek-reasoner）可能因 max_tokens
-      // 在思考阶段就耗尽，导致正文为空
+      // 在思考阶段就耗尽，导致正文为空。抛专用错误让上层加大额度重试。
       const finishReason = data.choices?.[0]?.finish_reason;
       if (finishReason === 'length') {
-        throw new Error('模型输出被 max_tokens 截断，正文为空。推理模型请调大 max_tokens 或改用非推理模型。');
+        throw new TruncatedEmptyOutputError(maxTokens);
       }
       throw new Error('LLM 返回内容为空，请检查模型名称是否正确');
     }
@@ -77,7 +123,11 @@ export class LLMService {
     };
   }
 
-  private async callClaude(messages: ChatMessage[], signal?: AbortSignal): Promise<LLMResponse> {
+  private async callClaude(
+    messages: ChatMessage[],
+    signal: AbortSignal | undefined,
+    maxTokens: number,
+  ): Promise<LLMResponse> {
     const systemMsg = messages.find(m => m.role === 'system')?.content || '';
     const nonSystemMessages = messages
       .filter(m => m.role !== 'system')
@@ -96,7 +146,7 @@ export class LLMService {
         model: this.config.model,
         system: systemMsg,
         messages: nonSystemMessages,
-        max_tokens: this.config.maxTokens ?? 2048,
+        max_tokens: maxTokens,
         temperature: this.config.temperature ?? 0.7,
       }),
       signal,
@@ -118,8 +168,16 @@ export class LLMService {
       );
     }
 
-    const content = data.content?.[0]?.text;
+    // Claude 开启 thinking 时首个 block 可能是 thinking，需取文本 block
+    const content = Array.isArray(data.content)
+      ? data.content.find((block: any) => block?.type === 'text')?.text
+        ?? data.content[0]?.text
+      : undefined;
+
     if (typeof content !== 'string' || content.trim() === '') {
+      if (data.stop_reason === 'max_tokens') {
+        throw new TruncatedEmptyOutputError(maxTokens);
+      }
       throw new Error(
         `Claude 返回内容为空或格式异常，请检查模型名称是否正确。${extractErrorMessage(raw)}`,
       );

--- a/src/services/llm/prompts.ts
+++ b/src/services/llm/prompts.ts
@@ -70,7 +70,7 @@ export function buildResumeParsingPrompt(rawText: string): { system: string; use
   "personal": {
     "name": "姓名",
     "gender": "性别",
-    "birthDate": "出生日期 (YYYY-MM-DD)",
+    "birthDate": "出生日期 (YYYY-MM，只有年份时填 YYYY)",
     "phone": "手机号",
     "email": "邮箱",
     "wechat": "微信号",
@@ -118,9 +118,15 @@ export function buildResumeParsingPrompt(rawText: string): { system: string; use
 
 规则：
 - 只输出JSON，不要其他文字
-- 缺失的字段填空字符串""
-- 日期统一为YYYY-MM格式
-- 教育/工作经历按时间倒序排列`;
+- 缺失的字段填空字符串""，不要猜测或编造
+- 日期统一为YYYY-MM格式；结束时间为在读/在职时填"至今"
+- 教育/工作经历按时间倒序排列
+- 原文来自PDF/Word提取，同一句话可能被硬换行拆到多行，请自行拼回完整句子
+- 个人信息常无标签并排写在开头（如"中共党员 2002年5月"），需按取值本身判断字段归属
+- 学校行常把学校、专业、学历、起止时间写在一行，需拆分到对应字段，不要整行填进school
+- 公司名不一定含"公司/集团"（如"科大讯飞""美团快驴""BOSS直聘"），按机构名识别
+- description保留该条经历下的完整工作内容，不要压缩成一句话
+- 简历中确实没有的信息（如未写性别）必须留空，不得由姓名或其他字段推断`;
 
   const user = `请解析以下简历：
 

--- a/src/services/llm/types.ts
+++ b/src/services/llm/types.ts
@@ -1,14 +1,24 @@
-export enum LLMProvider {
-  OPENAI = 'openai',
-  CLAUDE = 'claude',
-  DEEPSEEK = 'deepseek',
-  QWEN = 'qwen',
-  GLM = 'glm',
-  MINIMAX = 'minimax',
-  MIMO = 'mimo',
-  KIMI = 'kimi',
-  CUSTOM = 'custom',
-}
+/**
+ * 服务商标识。
+ *
+ * 用 const 对象而非 enum：enum 需要运行时代码生成，Node 的
+ * --experimental-strip-types 无法执行，会让本模块无法被测试直接加载。
+ * 常量与类型同名可以合并声明，`LLMProvider.CLAUDE` 与 `provider: LLMProvider`
+ * 两种用法保持不变。
+ */
+export const LLMProvider = {
+  OPENAI: 'openai',
+  CLAUDE: 'claude',
+  DEEPSEEK: 'deepseek',
+  QWEN: 'qwen',
+  GLM: 'glm',
+  MINIMAX: 'minimax',
+  MIMO: 'mimo',
+  KIMI: 'kimi',
+  CUSTOM: 'custom',
+} as const;
+
+export type LLMProvider = typeof LLMProvider[keyof typeof LLMProvider];
 
 export interface LLMConfig {
   provider: LLMProvider;
@@ -19,15 +29,38 @@ export interface LLMConfig {
   maxTokens?: number;
 }
 
+/**
+ * 输出上限默认值。
+ *
+ * 推理模型（deepseek-reasoner、mimo-v2.5-pro、MiniMax-M 系列等）会先消耗
+ * 大量 token 思考，思考内容也计入 max_tokens。简历解析的 JSON 本身就要
+ * 1500~2500 token，若上限只有 4096，思考阶段就耗尽，正文返回空。
+ */
+export const DEFAULT_MAX_TOKENS = 8192;
+
+/**
+ * 截断重试允许自动提升到的上限。到此仍拿不到正文即放弃 AI 解析，
+ * 回退本地规则，避免无限重试推高费用。
+ */
+export const MAX_TOKENS_CEILING = 32768;
+
 export const PROVIDER_PRESETS: Record<LLMProvider, {
   /** 下拉框中展示的名称 */
   label: string;
   /** OpenAI 兼容协议的 API 根地址（不含 /chat/completions） */
   baseUrl: string;
-  /** 选中该服务商时自动填入的默认模型 */
+  /**
+   * 选中该服务商时自动填入的默认模型。
+   * 一律选用非推理模型：推理模型的思考内容占用 max_tokens，
+   * 简历解析这类需要长 JSON 输出的任务容易在思考阶段耗尽额度、返回空正文。
+   */
   defaultModel: string;
-  /** 模型名称输入框的候选提示 */
+  /** 模型名称输入框的候选提示，只列非推理模型 */
   models: string[];
+  /** 已知的推理模型，仅用于在界面上提示风险，不作为默认值 */
+  reasoningModels?: string[];
+  /** 该服务商当前在售模型均为推理模型时置为 true */
+  reasoningOnly?: boolean;
   /** 获取 API Key 的控制台地址 */
   consoleUrl?: string;
 }> = {
@@ -35,21 +68,25 @@ export const PROVIDER_PRESETS: Record<LLMProvider, {
     label: 'OpenAI',
     baseUrl: 'https://api.openai.com/v1',
     defaultModel: 'gpt-4o-mini',
-    models: ['gpt-4o-mini', 'gpt-4o', 'gpt-4.1', 'gpt-4.1-mini'],
+    models: ['gpt-4o-mini', 'gpt-4o', 'gpt-4.1-mini', 'gpt-4.1'],
+    // o 系列与 gpt-5 系列为推理模型
+    reasoningModels: ['o4-mini', 'o3', 'gpt-5'],
     consoleUrl: 'https://platform.openai.com/api-keys',
   },
   [LLMProvider.CLAUDE]: {
     label: 'Claude',
     baseUrl: 'https://api.anthropic.com',
-    defaultModel: 'claude-sonnet-4-5',
-    models: ['claude-sonnet-4-5', 'claude-opus-4-5', 'claude-haiku-4-5'],
+    // 本插件不开启 extended thinking，这几个模型即按非推理方式响应
+    defaultModel: 'claude-haiku-4-5',
+    models: ['claude-haiku-4-5', 'claude-sonnet-4-5'],
     consoleUrl: 'https://console.anthropic.com/settings/keys',
   },
   [LLMProvider.DEEPSEEK]: {
     label: 'DeepSeek',
     baseUrl: 'https://api.deepseek.com/v1',
     defaultModel: 'deepseek-chat',
-    models: ['deepseek-chat', 'deepseek-reasoner'],
+    models: ['deepseek-chat'],
+    reasoningModels: ['deepseek-reasoner'],
     consoleUrl: 'https://platform.deepseek.com/api_keys',
   },
   [LLMProvider.QWEN]: {
@@ -57,20 +94,26 @@ export const PROVIDER_PRESETS: Record<LLMProvider, {
     baseUrl: 'https://dashscope.aliyuncs.com/compatible-mode/v1',
     defaultModel: 'qwen-plus',
     models: ['qwen-plus', 'qwen-turbo', 'qwen-max', 'qwen-long'],
+    reasoningModels: ['qwq-plus', 'qwen3-235b-a22b-thinking-2507'],
     consoleUrl: 'https://bailian.console.aliyun.com/',
   },
   [LLMProvider.GLM]: {
     label: 'GLM',
     baseUrl: 'https://open.bigmodel.cn/api/paas/v4',
     defaultModel: 'glm-4-flash',
-    models: ['glm-4-flash', 'glm-4-air', 'glm-4-plus', 'glm-4.6'],
+    models: ['glm-4-flash', 'glm-4-air', 'glm-4-plus'],
+    // glm-4.6 为混合推理模型，默认开启思考
+    reasoningModels: ['glm-4.6', 'glm-z1-air'],
     consoleUrl: 'https://open.bigmodel.cn/usercenter/apikeys',
   },
   [LLMProvider.MINIMAX]: {
     label: 'MiniMax',
     baseUrl: 'https://api.minimax.io/v1',
-    defaultModel: 'MiniMax-M3',
-    models: ['MiniMax-M3', 'MiniMax-M2.5'],
+    // M 系列均为推理模型，缺少非推理替代，故标记为仅有推理模型
+    defaultModel: 'MiniMax-M2.5',
+    models: [],
+    reasoningModels: ['MiniMax-M3', 'MiniMax-M2.5'],
+    reasoningOnly: true,
     consoleUrl: 'https://platform.minimax.io/',
   },
   [LLMProvider.MIMO]: {
@@ -78,15 +121,19 @@ export const PROVIDER_PRESETS: Record<LLMProvider, {
     // tp- 开头的 Token Plan key 只在 token-plan-cn 域名下有效；
     // 若使用标准 API key，请改为 https://api.xiaomimimo.com/v1
     baseUrl: 'https://token-plan-cn.xiaomimimo.com/v1',
+    // mimo-v2.5-pro 为推理模型，无非推理版本
     defaultModel: 'mimo-v2.5-pro',
-    models: ['mimo-v2.5-pro'],
+    models: [],
+    reasoningModels: ['mimo-v2.5-pro'],
+    reasoningOnly: true,
     consoleUrl: 'https://mimo.mi.com/',
   },
   [LLMProvider.KIMI]: {
     label: 'Kimi',
     baseUrl: 'https://api.moonshot.cn/v1',
-    defaultModel: 'moonshot-v1-8k',
-    models: ['moonshot-v1-8k', 'moonshot-v1-32k', 'moonshot-v1-128k', 'kimi-k2-0905-preview'],
+    defaultModel: 'moonshot-v1-32k',
+    models: ['moonshot-v1-32k', 'moonshot-v1-8k', 'moonshot-v1-128k', 'kimi-k2-0905-preview'],
+    reasoningModels: ['kimi-k2-thinking'],
     consoleUrl: 'https://platform.moonshot.cn/console/api-keys',
   },
   [LLMProvider.CUSTOM]: {

--- a/src/utils/nlpHelper.ts
+++ b/src/utils/nlpHelper.ts
@@ -1,4 +1,43 @@
-import type { ParsedResumeData, PersonalInfo, EducationInfo, ExperienceInfo } from '../shared/types';
+import type {
+  ParsedResumeData,
+  PersonalInfo,
+  EducationInfo,
+  ExperienceInfo,
+  ProjectInfo,
+} from '../shared/types';
+
+/** 简历章节类型 */
+export type SectionKind =
+  | 'basic'
+  | 'education'
+  | 'experience'
+  | 'project'
+  | 'campus'
+  | 'skills'
+  | 'selfEvaluation'
+  | 'award'
+  | 'other';
+
+export interface ResumeSection {
+  kind: SectionKind;
+  title: string;
+  lines: string[];
+}
+
+/**
+ * 章节标题识别规则。顺序有意义：先匹配更具体的标题
+ * （如「实习经历」要在「经历」之前，「项目经历」要在「实习」之前）。
+ */
+const SECTION_RULES: Array<[RegExp, SectionKind]> = [
+  [/^(?:自我评价|个人评价|自我介绍|个人总结|自我总结)$/, 'selfEvaluation'],
+  [/^(?:专业技能|技能特长|技能清单|个人技能|IT技能|专业能力|技能)$/i, 'skills'],
+  [/^(?:教育经历|教育背景|学历|学习经历|教育情况)$/, 'education'],
+  [/^(?:项目经历|项目经验|项目实践|科研经历|研究经历)$/, 'project'],
+  [/^(?:实习经历|实习经验|工作经历|工作经验|职业经历|实践经历|工作履历)$/, 'experience'],
+  [/^(?:校园经历|在校经历|校内经历|学生工作|社团经历|社会实践)$/, 'campus'],
+  [/^(?:获奖(?:情况|经历)?|荣誉奖项|奖励荣誉|证书|资格证书)$/, 'award'],
+  [/^(?:基本信息|个人信息|个人资料|联系方式)$/, 'basic'],
+];
 
 export class NLPHelper {
   // 提取手机号
@@ -11,6 +50,59 @@ export class NLPHelper {
   static extractEmail(text: string): string[] {
     const emailRegex = /[\w.-]+@[\w.-]+\.\w+/g;
     return text.match(emailRegex) || [];
+  }
+
+  /**
+   * 按章节标题把简历切段。
+   * 标题行的判断依据：整行（去掉装饰符号后）恰好等于某个已知章节名。
+   */
+  static splitSections(text: string): ResumeSection[] {
+    const sections: ResumeSection[] = [];
+    let current: ResumeSection = { kind: 'basic', title: '', lines: [] };
+
+    for (const rawLine of text.split('\n')) {
+      // 去掉列表符号、下划线装饰与首尾空白
+      const line = rawLine.replace(/^[\s\-*•·|]+/, '').replace(/[\s_=—–-]+$/, '').trim();
+      if (!line) continue;
+
+      const heading = line.replace(/^#+\s*/, '').replace(/[:：]$/, '').replace(/\s+/g, '');
+      const matched = heading.length <= 12
+        ? SECTION_RULES.find(([pattern]) => pattern.test(heading))
+        : undefined;
+
+      if (matched) {
+        if (current.lines.length > 0 || current.title) sections.push(current);
+        current = { kind: matched[1], title: heading, lines: [] };
+        continue;
+      }
+
+      current.lines.push(line);
+    }
+
+    if (current.lines.length > 0 || current.title) sections.push(current);
+
+    return sections;
+  }
+
+  /** 从一行中抽出起止日期，返回归一化的 YYYY-MM 与去掉日期后的剩余文本 */
+  static extractDateRange(line: string): {
+    startDate: string;
+    endDate: string;
+    rest: string;
+  } {
+    // 2024/09 - 2027/06、2025.10-2026.01、2023年10月至今、2020-09 ~ 2024-06
+    const rangeRegex =
+      /(\d{4})\s*[年./-]\s*(\d{1,2})\s*月?\s*(?:-|~|—|–|to|至|～)\s*(?:(\d{4})\s*[年./-]\s*(\d{1,2})\s*月?|(至今|现在|now|present))/i;
+
+    const match = line.match(rangeRegex);
+    if (match) {
+      const pad = (v: string) => v.padStart(2, '0');
+      const startDate = `${match[1]}-${pad(match[2])}`;
+      const endDate = match[3] ? `${match[3]}-${pad(match[4])}` : '至今';
+      return { startDate, endDate, rest: line.replace(match[0], ' ').trim() };
+    }
+
+    return { startDate: '', endDate: '', rest: line };
   }
 
   // 提取日期
@@ -81,6 +173,236 @@ export class NLPHelper {
     }
 
     return [...new Set(companies)];
+  }
+
+  /**
+   * 解析教育经历章节。
+   * 典型行：「北京师范大学 理论经济学专业 · 硕士 2024/09 - 2027/06」
+   * 学校、专业、学历、日期的先后顺序不固定，因此按特征各自识别，
+   * 而不是依赖位置切分。
+   */
+  static parseEducationSection(lines: string[]): Partial<EducationInfo>[] {
+    const degreeRegex = /(博士后|博士|硕士|研究生|本科|学士|大专|专科|高中|中专|MBA|EMBA)/;
+    const schoolRegex = /(大学|学院|学校|University|College|Institute|School)/i;
+    const entries: Partial<EducationInfo>[] = [];
+
+    for (const line of lines) {
+      const { startDate, endDate, rest } = NLPHelper.extractDateRange(line);
+      if (!schoolRegex.test(rest)) continue;
+
+      // 以分隔符切成若干片段，逐片判定角色
+      const parts = rest
+        .split(/[·|｜,，、\s]+|\s{2,}/)
+        .map(p => p.trim())
+        .filter(Boolean);
+
+      let school = '';
+      let college = '';
+      let major = '';
+      let degree = '';
+      let gpa = '';
+
+      for (const part of parts) {
+        const gpaMatch = part.match(/(?:GPA|绩点|均分|平均分)[:：\s]*([\d.]+(?:\/[\d.]+)?)/i);
+        if (gpaMatch) {
+          gpa ||= gpaMatch[1];
+          continue;
+        }
+        if (!degree && degreeRegex.test(part) && part.length <= 8) {
+          degree = (part.match(degreeRegex) as RegExpMatchArray)[1];
+          const remainder = part.replace(degreeRegex, '').trim();
+          if (remainder && !major && /专业/.test(remainder)) major = remainder;
+          continue;
+        }
+        if (!school && schoolRegex.test(part)) {
+          // 「XX大学XX学院」拆成学校与学院
+          const collegeMatch = part.match(/^(.*?(?:大学|University))(.+?(?:学院|系|School))$/i);
+          if (collegeMatch) {
+            school = collegeMatch[1].trim();
+            college = collegeMatch[2].trim();
+          } else {
+            school = part;
+          }
+          continue;
+        }
+        if (!college && /(?:学院|系|School)$/i.test(part) && school) {
+          college = part;
+          continue;
+        }
+        if (!major && /专业/.test(part)) {
+          major = part.replace(/专业$/, '').trim();
+          continue;
+        }
+        // 没有「专业」字样时，取一个不含日期与学历的短片段兜底
+        if (!major && part.length <= 20 && !/\d/.test(part) && !degreeRegex.test(part)) {
+          major = part;
+        }
+      }
+
+      if (!school) continue;
+
+      entries.push({
+        id: `edu-${entries.length}`,
+        school,
+        ...(college ? { college } : {}),
+        major,
+        degree,
+        startDate,
+        endDate,
+        ...(gpa ? { gpa } : {}),
+      });
+    }
+
+    return entries;
+  }
+
+  /**
+   * 解析实习/工作经历章节。
+   * 条目头部行的特征是含起止日期（如「科大讯飞 AI产品经理 2026/03 - 2026/06」），
+   * 其后不含日期的行归为该条目的描述。这样不依赖公司名关键词，
+   * 「科大讯飞」「美团快驴」「BOSS直聘」这类不含「公司/集团」的名称也能识别。
+   */
+  static parseExperienceSection(lines: string[]): Partial<ExperienceInfo>[] {
+    const entries: Partial<ExperienceInfo>[] = [];
+    let currentDescription: string[] = [];
+
+    const flushDescription = () => {
+      if (entries.length > 0 && currentDescription.length > 0) {
+        entries[entries.length - 1].description = currentDescription.join('\n');
+      }
+      currentDescription = [];
+    };
+
+    for (const line of lines) {
+      const { startDate, endDate, rest } = NLPHelper.extractDateRange(line);
+
+      // 含日期且剩余部分较短 → 视为新条目的头部行
+      if (startDate && rest.length <= 40) {
+        flushDescription();
+
+        const parts = rest.split(/[|｜·，,、\s]{1,}/).map(p => p.trim()).filter(Boolean);
+        const { company, position } = NLPHelper.splitCompanyPosition(parts);
+
+        entries.push({
+          id: `exp-${entries.length}`,
+          company,
+          position,
+          startDate,
+          endDate,
+          description: '',
+        });
+        continue;
+      }
+
+      if (entries.length > 0) currentDescription.push(line);
+    }
+
+    flushDescription();
+
+    return entries;
+  }
+
+  /**
+   * 从头部行的片段中区分公司名与职位。
+   *
+   * 不能只看是否含职位关键词：「国务院发展研究中心大数据研究院」含「研究」，
+   * 会被误判成职位。因此优先用机构特征词锚定公司，职位则要求关键词落在
+   * 片段末尾（中文职位名几乎都以职级词收尾）。
+   */
+  static splitCompanyPosition(parts: string[]): { company: string; position: string } {
+    // 以职级词结尾才算职位名
+    const positionRegex =
+      /(经理|主管|总监|工程师|开发|设计师|运营|实习生|实习|助理|专员|顾问|分析师|研究员|销售|测试|讲师|教师|研究|策划|编辑|BP|HRBP|HR|PM|PMO|CEO|CTO|COO)$/i;
+    // 机构特征词：出现即优先判为公司
+    const orgRegex =
+      /(公司|集团|有限|股份|中心|研究院|研究所|学院|大学|银行|事务所|工作室|实验室|部|局|署|厅|委|社|台|网|Ltd|Inc|Corp|LLC|Group|Technology|Technologies)$/i;
+
+    if (parts.length === 0) return { company: '', position: '' };
+    if (parts.length === 1) {
+      return orgRegex.test(parts[0]) || !positionRegex.test(parts[0])
+        ? { company: parts[0], position: '' }
+        : { company: '', position: parts[0] };
+    }
+
+    // 机构特征词命中的片段直接作为公司，其余合并成职位
+    const orgIndex = parts.findIndex(p => orgRegex.test(p));
+    if (orgIndex !== -1) {
+      return {
+        company: parts[orgIndex],
+        position: parts.filter((_, i) => i !== orgIndex).join(' '),
+      };
+    }
+
+    // 否则找以职级词结尾的片段当职位，取最后一个命中项
+    // （「科大讯飞 AI产品经理」里只有后者以「经理」结尾）
+    let positionIndex = -1;
+    for (let i = parts.length - 1; i >= 0; i--) {
+      if (positionRegex.test(parts[i])) {
+        positionIndex = i;
+        break;
+      }
+    }
+
+    if (positionIndex === -1) {
+      return { company: parts[0], position: parts.slice(1).join(' ') };
+    }
+
+    return {
+      position: parts[positionIndex],
+      company: parts.filter((_, i) => i !== positionIndex).join(' '),
+    };
+  }
+
+  /** 解析项目经历章节，规则与工作经历一致，仅字段名不同 */
+  static parseProjectSection(lines: string[]): Partial<ProjectInfo>[] {
+    return NLPHelper.parseExperienceSection(lines).map((exp, index) => ({
+      id: `proj-${index}`,
+      name: exp.company || '',
+      role: exp.position || '',
+      startDate: exp.startDate || '',
+      endDate: exp.endDate || '',
+      description: exp.description || '',
+      achievements: '',
+    }));
+  }
+
+  /**
+   * 从技能章节文本中拆出技能条目。
+   *
+   * 技能章节常写成整句（「运用SQL、Python进行数据分析」），
+   * 直接按顿号切会得到「SPSS进行数据提取」这类残句，
+   * 因此切分后要裁掉动词短语并丢弃仍像句子的片段。
+   */
+  static parseSkillsSection(lines: string[]): string[] {
+    const skills: string[] = [];
+
+    for (const line of lines) {
+      // 「常用办公软件：Excel、Word」→ 取冒号后的部分
+      const colonIndex = Math.max(line.indexOf('：'), line.indexOf(':'));
+      const afterColon = colonIndex >= 0 ? line.slice(colonIndex + 1) : line;
+
+      for (const candidate of afterColon.split(/[、,，/;；]/)) {
+        const cleaned = candidate
+          .trim()
+          // 去掉开头的动词（熟练运用 SQL → SQL）
+          .replace(/^(?:熟练|熟悉|掌握|了解|精通|擅长|能够|运用|使用|常用|具备)+/, '')
+          // 截断到动词短语之前（SPSS进行数据提取 → SPSS）
+          .split(/(?:进行|用于|完成|实现|开发了?|绘制|提高)/)[0]
+          // 去掉列举尾巴（Claude Code等AI工具 → Claude Code）
+          .replace(/等[^、,，]*$/, '')
+          .replace(/[。；、，]+$/, '')
+          .trim();
+
+        if (!cleaned || cleaned.length > 16) continue;
+        // 仍含句子成分（的/是/有/和/与…）说明不是技能名
+        if (/[的是有并及和与或对]|[。；！？]/.test(cleaned)) continue;
+        if (!/[A-Za-z0-9一-龥]/.test(cleaned)) continue;
+
+        skills.push(cleaned);
+      }
+    }
+
+    return [...new Set(skills)];
   }
 
   // 提取技能
@@ -155,82 +477,178 @@ export class NLPHelper {
     return result;
   }
 
-  // 从简历文本中提取结构化数据
+  /**
+   * 提取无标签的个人字段。
+   * 很多简历模板把信息直接并排写在页眉，如「中共党员 2002年5月」，
+   * 没有「政治面貌:」这类标签，只能按值本身的特征识别。
+   * 仅在文本靠前的区域查找，避免正文里的词被误当作个人信息。
+   */
+  static extractUnlabeledFields(text: string, headLines = 12): Partial<PersonalInfo> {
+    const result: Partial<PersonalInfo> = {};
+    const head = text.split('\n').slice(0, headLines).join('\n');
+
+    const politicalMatch = head.match(
+      /(中共党员|中共预备党员|预备党员|共青团员|中共党员\(预备\)|党员|团员|群众|民主党派|无党派)/
+    );
+    if (politicalMatch) result.politicalStatus = politicalMatch[1];
+
+    // 出生日期：2002年5月 / 2002.05 / 2002-05；排除明显是学历起止年份的范围
+    const birthMatch = head.match(/(?<!\d)(19[5-9]\d|20[0-2]\d)\s*[年.\-/]\s*(\d{1,2})\s*月?(?!\s*[-~—–至])/);
+    if (birthMatch) {
+      result.birthDate = `${birthMatch[1]}-${birthMatch[2].padStart(2, '0')}`;
+    }
+
+    // 性别：作为独立词出现（前后是分隔符或行首行尾），避免匹配「男装」「女装」等
+    const genderMatch = head.match(/(?:^|[\s|｜/·,，、])([男女])(?:$|[\s|｜/·,，、])/m);
+    if (genderMatch) result.gender = genderMatch[1];
+
+    const ethnicityMatch = head.match(/([一-龥]{1,4})族(?![\s\S]{0,2}自治)/);
+    if (ethnicityMatch) result.ethnicity = `${ethnicityMatch[1]}族`;
+
+    const idMatch = head.match(/(?<!\d)(\d{17}[\dXx])(?!\d)/);
+    if (idMatch) result.idCard = idMatch[1];
+
+    return result;
+  }
+
+  /**
+   * 姓名候选：短、无标点数字、不是章节标题，
+   * 也不能是政治面貌/性别/民族/婚育状况这类会与姓名并排出现的取值。
+   */
+  private static looksLikeName(line: string): boolean {
+    const sectionWords =
+      /(简历|基本信息|教育|实习|工作|经历|技能|项目|评价|校园|获奖|荣誉|证书|联系)/;
+    // 页眉里常见的非姓名取值，如「中共党员 2002年5月」
+    const fieldValues =
+      /^(?:中共)?(?:预备)?党员$|^共青团员$|^团员$|^群众$|^民主党派$|^无党派$|^[男女]$|^.{1,3}族$|^(?:已|未)婚(?:已育|未育)?$|^汉$/;
+
+    return (
+      line.length >= 2 &&
+      line.length <= 6 &&
+      !sectionWords.test(line) &&
+      !fieldValues.test(line) &&
+      !/[:：@\d]/.test(line)
+    );
+  }
+
+  /**
+   * 从简历文本中提取结构化数据。
+   *
+   * 以章节为单位解析：先按标题切段，再用各段专属规则处理。
+   * 这样「大学生创业训练计划」不会因为含「大学」被当成学校，
+   * 描述文字也不会混进公司名。识别不到任何章节标题时，
+   * 退回到全文关键词扫描。
+   */
   static parseResumeText(text: string): ParsedResumeData {
+    const sections = this.splitSections(text);
+    const hasSections = sections.some(s => s.kind !== 'basic' && s.kind !== 'other');
+
+    // 联系方式在全文任意位置都可能出现，直接全文扫描
+    const personal: Partial<PersonalInfo> = {};
     const phones = this.extractPhone(text);
     const emails = this.extractEmail(text);
-    const schools = this.extractSchools(text);
-    const companies = this.extractCompanies(text);
-    const skills = this.extractSkills(text);
+    if (phones.length > 0) personal.phone = phones[0];
+    if (emails.length > 0) personal.email = emails[0];
 
-    // 构建个人信息
-    const personal: Partial<PersonalInfo> = {};
-    if (phones.length > 0) {
-      personal.phone = phones[0];
-    }
-    if (emails.length > 0) {
-      personal.email = emails[0];
-    }
-
-    // 提取「标签: 值」形式的字段（简历常见写法，如「生日: 2002年5月」）
+    // 「标签: 值」优先，其次才是无标签的特征识别，避免覆盖更可靠的结果
+    Object.assign(personal, this.extractUnlabeledFields(text));
     Object.assign(personal, this.extractLabeledFields(text));
 
-    // 尝试提取姓名。标签式（姓名: xxx）已在上一步处理，此处按位置推断。
     if (!personal.name) {
-      const lines = text.split('\n')
-        .map(l => l.replace(/^#+\s*/, '').trim())
-        .filter(l => l.length > 0);
+      const nameFromTitle = this.inferName(text);
+      if (nameFromTitle) personal.name = nameFromTitle;
+    }
 
-      // 文档标题常为「XXX的个人简历」，可从中反推姓名
-      for (const line of lines.slice(0, 8)) {
-        const titleMatch = line.match(/^(.{2,4})的(?:个人)?简历/);
-        if (titleMatch) {
-          personal.name = titleMatch[1];
+    let education: Partial<EducationInfo>[] = [];
+    let experience: Partial<ExperienceInfo>[] = [];
+    let projects: Partial<ProjectInfo>[] = [];
+    let skills: string[] = [];
+
+    for (const section of sections) {
+      switch (section.kind) {
+        case 'education':
+          education.push(...this.parseEducationSection(section.lines));
           break;
-        }
-      }
-
-      // 否则取靠前的一个短行（排除章节标题与联系方式）
-      if (!personal.name) {
-        const sectionWords = /(简历|基本信息|教育|实习|工作|经历|技能|项目|评价|校园|获奖)/;
-        for (const line of lines.slice(0, 8)) {
-          if (line.length >= 2 && line.length <= 6
-              && !sectionWords.test(line)
-              && !/[:：@\d]/.test(line)) {
-            personal.name = line;
-            break;
+        case 'experience':
+          experience.push(...this.parseExperienceSection(section.lines));
+          break;
+        case 'project':
+          projects.push(...this.parseProjectSection(section.lines));
+          break;
+        case 'skills':
+          skills.push(...this.parseSkillsSection(section.lines));
+          break;
+        case 'selfEvaluation':
+          if (!personal.selfEvaluation && section.lines.length > 0) {
+            personal.selfEvaluation = section.lines.join('');
           }
-        }
+          break;
+        default:
+          break;
       }
     }
 
-    // 构建教育经历
-    const education: Partial<EducationInfo>[] = schools.map((school, index) => ({
-      id: `edu-${index}`,
-      school: school,
-      major: '',
-      degree: '',
-      startDate: '',
-      endDate: ''
-    }));
+    // 重新编号，多个同类章节合并后 id 才不会重复
+    education = education.map((e, i) => ({ ...e, id: `edu-${i}` }));
+    experience = experience.map((e, i) => ({ ...e, id: `exp-${i}` }));
+    projects = projects.map((p, i) => ({ ...p, id: `proj-${i}` }));
 
-    // 构建工作经历
-    const experience: Partial<ExperienceInfo>[] = companies.map((company, index) => ({
-      id: `exp-${index}`,
-      company: company,
-      position: '',
-      startDate: '',
-      endDate: '',
-      description: ''
-    }));
+    // 没有章节标题的简历退回全文扫描。学校行同样带日期范围，
+    // 若不先剔除会被工作经历解析器当成一条经历，故按行分流。
+    if (!hasSections) {
+      const allLines = text.split('\n').map(l => l.trim()).filter(Boolean);
+      const educationLines: string[] = [];
+      const otherLines: string[] = [];
+
+      for (const line of allLines) {
+        if (this.parseEducationSection([line]).length > 0) {
+          educationLines.push(line);
+        } else {
+          otherLines.push(line);
+        }
+      }
+
+      if (education.length === 0) {
+        education = this.parseEducationSection(educationLines)
+          .map((e, i) => ({ ...e, id: `edu-${i}` }));
+      }
+      if (experience.length === 0) {
+        experience = this.parseExperienceSection(otherLines)
+          .map((e, i) => ({ ...e, id: `exp-${i}` }));
+      }
+    }
+
+    if (skills.length === 0) skills = this.extractSkills(text);
 
     return {
       personal: Object.keys(personal).length > 0 ? personal : undefined,
       education: education.length > 0 ? education : undefined,
       experience: experience.length > 0 ? experience : undefined,
+      projects: projects.length > 0 ? projects : undefined,
       skills: skills.length > 0 ? skills : undefined,
       rawText: text
     };
+  }
+
+  /** 从标题或靠前的短行推断姓名 */
+  private static inferName(text: string): string {
+    const lines = text.split('\n')
+      .map(l => l.replace(/^#+\s*/, '').trim())
+      .filter(l => l.length > 0);
+
+    // 文档标题常为「XXX的个人简历」，可从中反推姓名
+    for (const line of lines.slice(0, 8)) {
+      const titleMatch = line.match(/^(.{2,4})的(?:个人)?简历/);
+      if (titleMatch) return titleMatch[1];
+    }
+
+    // 页眉常把姓名与联系方式排在一行，如「董星 dst3056@qq.com 1980...」
+    for (const line of lines.slice(0, 8)) {
+      const first = line.split(/[\s|｜/·,，、]+/)[0]?.trim();
+      if (first && this.looksLikeName(first)) return first;
+    }
+
+    return '';
   }
 
   // 清理和标准化文本

--- a/src/utils/resume-parse.test.ts
+++ b/src/utils/resume-parse.test.ts
@@ -1,0 +1,152 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { NLPHelper } from './nlpHelper.ts';
+
+/**
+ * 取自真实简历（Canva 导出 PDF）的文本结构：
+ * 章节标题独立成行，个人信息无标签并排在页眉，
+ * 学校/公司行把多个字段挤在一行，长描述被硬换行拆开。
+ */
+const RESUME = [
+  '中共党员 2002年5月',
+  '张明 zhangming@example.com 13812345678',
+  '教育经历',
+  '北京师范大学 理论经济学专业 · 硕士 2024/09 - 2027/06',
+  '中国人民大学 劳动经济学专业 · 本科 2020/09 - 2024/06',
+  '实习经历',
+  '科大讯飞 AI产品经理 2026/03 - 2026/06',
+  '产品迭代与功能优化：参与多模态医疗Agent产品从0到1的搭建、规划与迭代，推动产品体验持续优',
+  '化。',
+  '美团快驴 数据运营 2025.10-2026.01',
+  '数据支持与看板搭建：独立承担业务数据支持工作，编写SQL完成数据提取与清洗。',
+  '国务院发展研究中心大数据研究院 产品经理 2025.06-2025.09',
+  '产品更新与迭代：深度参与大数据可视化平台的更新与迭代。',
+  '校园经历',
+  '参与大学生创业训练计划，负责市场分析与财务模块，获得国家级结项。',
+  '专业技能',
+  '运用SQL、Python、Stata、SPSS进行数据提取、清洗和分析。',
+  '常用办公软件：Excel、Word、PowerPoint等。',
+  '自我评价',
+  '本人性格开朗乐观，热情待人，有强烈的责任心。',
+].join('\n');
+
+test('按章节标题切分简历', () => {
+  const kinds = NLPHelper.splitSections(RESUME).map(s => s.kind);
+  assert.deepEqual(kinds, [
+    'basic', 'education', 'experience', 'campus', 'skills', 'selfEvaluation',
+  ]);
+});
+
+test('提取无标签的个人信息', () => {
+  const personal = NLPHelper.parseResumeText(RESUME).personal!;
+  assert.equal(personal.name, '张明');
+  assert.equal(personal.politicalStatus, '中共党员');
+  assert.equal(personal.birthDate, '2002-05');
+  assert.equal(personal.phone, '13812345678');
+  assert.equal(personal.email, 'zhangming@example.com');
+});
+
+test('政治面貌不会被当成姓名', () => {
+  const personal = NLPHelper.parseResumeText(RESUME).personal!;
+  assert.notEqual(personal.name, '中共党员');
+});
+
+test('简历未写性别时不推断', () => {
+  const personal = NLPHelper.parseResumeText(RESUME).personal!;
+  assert.ok(!personal.gender, `不应推断性别，实际得到 ${personal.gender}`);
+});
+
+test('自我评价按章节提取', () => {
+  const personal = NLPHelper.parseResumeText(RESUME).personal!;
+  assert.match(personal.selfEvaluation || '', /性格开朗乐观/);
+});
+
+test('学校行拆分为学校/专业/学历/起止时间', () => {
+  const education = NLPHelper.parseResumeText(RESUME).education!;
+  assert.equal(education.length, 2);
+  assert.deepEqual(
+    { ...education[0], id: undefined },
+    {
+      id: undefined,
+      school: '北京师范大学',
+      major: '理论经济学',
+      degree: '硕士',
+      startDate: '2024-09',
+      endDate: '2027-06',
+    }
+  );
+  assert.equal(education[1].school, '中国人民大学');
+  assert.equal(education[1].degree, '本科');
+});
+
+test('教育经历不收录含「大学」的校园活动描述', () => {
+  const education = NLPHelper.parseResumeText(RESUME).education!;
+  const schools = education.map(e => e.school);
+  assert.ok(
+    !schools.some(s => s?.includes('创业训练计划')),
+    `校园活动被误判为学校：${JSON.stringify(schools)}`
+  );
+});
+
+test('识别不含「公司/集团」的机构名', () => {
+  const experience = NLPHelper.parseResumeText(RESUME).experience!;
+  assert.equal(experience.length, 3);
+  assert.equal(experience[0].company, '科大讯飞');
+  assert.equal(experience[0].position, 'AI产品经理');
+  assert.equal(experience[1].company, '美团快驴');
+  assert.equal(experience[1].position, '数据运营');
+});
+
+test('机构名含「研究」时不与职位对调', () => {
+  const experience = NLPHelper.parseResumeText(RESUME).experience!;
+  assert.equal(experience[2].company, '国务院发展研究中心大数据研究院');
+  assert.equal(experience[2].position, '产品经理');
+});
+
+test('经历起止时间归一化为 YYYY-MM', () => {
+  const experience = NLPHelper.parseResumeText(RESUME).experience!;
+  assert.equal(experience[1].startDate, '2025-10');
+  assert.equal(experience[1].endDate, '2026-01');
+});
+
+test('描述归入所属经历且不串段', () => {
+  const experience = NLPHelper.parseResumeText(RESUME).experience!;
+  assert.match(experience[0].description || '', /多模态医疗Agent/);
+  assert.ok(
+    !experience[0].description?.includes('美团'),
+    '下一条经历的内容串入了上一条'
+  );
+  assert.match(experience[1].description || '', /编写SQL/);
+});
+
+test('技能只保留技能名，不含句子片段', () => {
+  const skills = NLPHelper.parseResumeText(RESUME).skills!;
+  for (const expected of ['SQL', 'Python', 'Stata', 'SPSS', 'Excel', 'Word']) {
+    assert.ok(skills.includes(expected), `缺少技能 ${expected}`);
+  }
+  for (const skill of skills) {
+    assert.ok(skill.length <= 16, `技能项过长：${skill}`);
+    assert.ok(!/[。；]/.test(skill), `技能项含句子标点：${skill}`);
+  }
+});
+
+test('「至今」结束时间', () => {
+  const range = NLPHelper.extractDateRange('某公司 产品经理 2025/03 - 至今');
+  assert.equal(range.startDate, '2025-03');
+  assert.equal(range.endDate, '至今');
+});
+
+test('无章节标题的简历回退到全文扫描', () => {
+  const plain = [
+    '李华 lihua@example.com 13900001111',
+    '清华大学 计算机科学与技术专业 · 本科 2019/09 - 2023/06',
+    '腾讯科技有限公司 后端工程师 2023/07 - 至今',
+  ].join('\n');
+
+  const parsed = NLPHelper.parseResumeText(plain);
+  assert.equal(parsed.education?.[0].school, '清华大学');
+  assert.equal(parsed.education?.[0].degree, '本科');
+  assert.equal(parsed.experience?.[0].company, '腾讯科技有限公司');
+  assert.equal(parsed.experience?.[0].position, '后端工程师');
+  assert.equal(parsed.experience?.[0].endDate, '至今');
+});


### PR DESCRIPTION
## 背景

上传简历后提示「解析完成」，但实际只有手机号和邮箱写入资料；配置 AI 服务后仍很粗糙，教育经历整行填入、实习经历完全识别不出；上传 DOCX 直接报 `document is not defined`。

## 根因与修复

**1. PDF 提取丢失视觉顺序**

按内容流顺序拼接文本。设计工具（如 Canva）把章节标题放在独立图层最后绘制，于是「教育经历」「实习经历」等标题全部堆到文末，与各自内容脱节 —— 送进 LLM 的文本里「实习经历」后面什么都没有，模型无从判断段落归属。

改为按坐标重排：Y 聚行（半个字高容差）、行内按 X 排序，并按块间距决定是否补空格（中文 PDF 常把相邻字拆成多块，无条件加空格会在词内插空格）。

**2. 正则解析器不区分章节**

原先全文扫「大学」关键词并整行填入 `school`，既把「参与大学生创业训练计划…」误判为学校，也提不出专业/学历/日期；公司名关键词表（`公司|集团|科技|有限`）对「科大讯飞」「美团快驴」「BOSS直聘」全部落空，这是实习经历一条都识别不出的原因。

改为章节感知：先按标题切段，各段用专属规则解析。经历条目改用「行内含起止日期」判定，不再依赖公司名关键词。补充了无标签个人字段的识别（页眉常写成「中共党员 2002年5月」，没有 `政治面貌:` 这类标签）。

**3. DOCX 在 service worker 报错**

mammoth 本身用纯 JS 的 `@xmldom/xmldom`，但其依赖 bluebird 在**模块求值时**挑选调度器：MV3 环境无 `process` 却有 `MutationObserver`，一旦 `getNativePromise()` 校验失败（该校验要求 `{}.toString.call(p) === "[object Promise]"`），就落到 `document.createElement` 分支抛 ReferenceError。

未去猜 bluebird 的分支选择，而是让 DOCX 与 PDF 一致，只在有 DOM 的上下文解析。

## 其他修复

- 解析结果的空值不再覆盖已填字段；空数组不再清空已有记录（`parsed || current` 中空数组是真值）
- AI 解析失败原本静默回退正则，用户会误以为 AI 生效，现将原因回报到界面
- 输出额度默认 4096 → 8192，截断且正文为空时自动加倍重试至 32768，到顶即回退本地规则
- 各服务商默认模型改为非推理模型，并固定提示推荐非推理模型
- 修正 Claude 开启 thinking 时误取 thinking block 而报「返回内容为空」
- `LLMProvider` 由 `enum` 改为 const 对象，使该模块可被测试直接加载

## 验证

以真实简历（2 页，Canva 导出）实测，提取结果从「手机号 + 邮箱」变为：

- 个人信息 6 项（姓名、政治面貌、出生日期、手机、邮箱、自我评价）
- 教育经历 2 条，学校/专业/学历/起止时间均已拆分
- 实习经历 4 条，公司与职位正确，描述归入对应条目
- 技能 14 项

新增 24 个测试（共 74 个，全部通过），覆盖字段提取、额度重试与 offscreen 路由。另核对构建产物：`dist/background.js` 中 `extractRawText` 出现 0 次，mammoth 已不在 service worker 可达范围。

`npm test` / `npm run lint` / `npm run build` 均通过。

## 已知未改动

- 教育/实习经历仍为整体替换而非逐条合并，手工精修过的条目重新上传会被覆盖（已改为仅在解析出非空结果时替换）
- 扫描版（图片型）PDF 无文本层，仍无法提取，需 OCR；界面会明确提示
- MiniMax 与 MiMo 在售模型均为推理模型，未找到可确认的非推理版本，故未编写模型名，改为在界面提示改用其他服务商

🤖 Generated with [Claude Code](https://claude.com/claude-code)